### PR TITLE
he tunnel too slow

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
     },
     "nixos-2605": {
       "locked": {
-        "lastModified": 1779622335,
-        "narHash": "sha256-ViA62qtL5za7V3d5I8OA9q9JcFhsVAiL5jVHwEclWqk=",
+        "lastModified": 1784280462,
+        "narHash": "sha256-DtoqIqM7VkR6NxAkcLpMwmi02USwWb3JdmNGLyhthc0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "705e9929918b43bd7b715dc0a878ac870449bb03",
+        "rev": "293d6abedf0478e681a4dfcfcb35b30fc796a32f",
         "type": "github"
       },
       "original": {
@@ -54,12 +54,15 @@
       }
     },
     "nixos-hardware": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1779258371,
-        "narHash": "sha256-j1iZsLy6oFApqR1oiDmHhvkwxXqcNi0aoSJj643LuwU=",
+        "lastModified": 1784310968,
+        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "c97bc4d15bd3473dd095e8e8ba57330ab1943a77",
+        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
         "type": "github"
       },
       "original": {
@@ -70,11 +73,11 @@
     },
     "nixos-master": {
       "locked": {
-        "lastModified": 1781208676,
-        "narHash": "sha256-l6xcABdI2sr4quZ9zYvPnA0KhvDBA6YCrXiw3KNTtwI=",
+        "lastModified": 1784328216,
+        "narHash": "sha256-C0cLJMdRdcoI9cv1TeA4ECY2TX8Ev5BACrimS9lNveo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9b3243c6051fc796ca10ff255b80f45f2238747e",
+        "rev": "dbd49a8e8b301a9716f21fc1ee005ce82e745604",
         "type": "github"
       },
       "original": {
@@ -86,11 +89,11 @@
     },
     "nixos-unstable": {
       "locked": {
-        "lastModified": 1779560665,
-        "narHash": "sha256-tpyBcxPpcQb8ukyNF7DoCwfSY3VPsxHoYwj00Cayv5o=",
+        "lastModified": 1784120854,
+        "narHash": "sha256-KesHgItiZPgGX740axSiQLcIQ8D24MDqNpkKYWIek8k=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "64c08a7ca051951c8eae34e3e3cb1e202fe36786",
+        "rev": "753cc8a3a87467296ddd1fa93f0cc3e81120ee46",
         "type": "github"
       },
       "original": {
@@ -102,18 +105,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772198003,
-        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
-        "type": "github"
+        "lastModified": 1767892417,
+        "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
+        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "type": "tarball",
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre924538.3497aa5c9457/nixexprs.tar.xz"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "nixpkgs-darwin": {
@@ -128,6 +128,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1772198003,
+        "narHash": "sha256-I45esRSssFtJ8p/gLHUZ1OUaaTaVLluNkABkk6arQwE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "dd9b079222d43e1943b6ebd802f04fd959dc8e61",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -147,7 +163,7 @@
     },
     "scale-signs": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1774202316,
@@ -171,11 +187,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/imgs/gnome-installer.nix
+++ b/imgs/gnome-installer.nix
@@ -15,6 +15,10 @@
   };
   nixpkgs.config.allowUnfree = true;
 
+  # silence warning about the pre-26.11 default; the installer never boots
+  # from a ZFS root so force-importing is unnecessary
+  boot.zfs.forceImportRoot = false;
+
   environment.systemPackages = with pkgs; [
     dosfstools
     fish

--- a/machines/galleta/configuration.nix
+++ b/machines/galleta/configuration.nix
@@ -86,7 +86,7 @@ in
 
     # Router advertisements for LAN IPv6
     services.radvd = {
-      enable = true;
+      enable = false;
       config = ''
         interface ${lanIf} {
           AdvSendAdvert on;

--- a/machines/muir/configuration.nix
+++ b/machines/muir/configuration.nix
@@ -16,6 +16,14 @@ in
     autoGC = false;
   };
 
+  # electron 39 is EOL upstream but still required by bitwarden-desktop
+  # and other electron apps on nixos-26.05
+  # https://github.com/NixOS/nixpkgs/issues/526914
+  # https://github.com/bitwarden/clients/issues/21581
+  nixpkgs.config.permittedInsecurePackages = [
+    "electron-39.8.10"
+  ];
+
   hardware = {
     enableRedistributableFirmware = lib.mkDefault true;
     bluetooth.enable = false;

--- a/machines/watson/configuration.nix
+++ b/machines/watson/configuration.nix
@@ -169,7 +169,6 @@ in
           go
           gopls
           go-outline
-          openrct2
           signal-desktop
           slack
           spotify
@@ -178,6 +177,7 @@ in
 
         masterPackages = with pkgs-master; [
           claude-code
+          openrct2
         ];
 
         selfPackages = [

--- a/machines/watson/configuration.nix
+++ b/machines/watson/configuration.nix
@@ -224,7 +224,9 @@ in
 
   services.ollama = {
     enable = true;
-    package = pkgs.ollama-cuda;
+    # only compile CUDA kernels for the RTX 3060 (sm_86) instead of all
+    # 9 default architectures, ollama-cuda is never in the binary cache
+    package = pkgs.ollama-cuda.override { cudaArches = [ "sm_86" ]; };
     loadModels = [
       # multimodal (vision + text)
       "gemma3:12b" # ~8GB

--- a/machines/watson/configuration.nix
+++ b/machines/watson/configuration.nix
@@ -15,6 +15,14 @@ in
     enable = true;
     autoGC = false;
   };
+
+  # electron 39 is EOL upstream but still required by bitwarden-desktop
+  # and other electron apps on nixos-26.05
+  # https://github.com/NixOS/nixpkgs/issues/526914
+  # https://github.com/bitwarden/clients/issues/21581
+  nixpkgs.config.permittedInsecurePackages = [
+    "electron-39.8.10"
+  ];
   mynixcfg.alloy = {
     enable = true;
     enableTracing = true;

--- a/machines/watson/configuration.nix
+++ b/machines/watson/configuration.nix
@@ -228,19 +228,17 @@ in
     # 9 default architectures, ollama-cuda is never in the binary cache
     package = pkgs.ollama-cuda.override { cudaArches = [ "sm_86" ]; };
     loadModels = [
-      # multimodal (vision + text)
-      "gemma3:12b" # ~8GB
-      "llama3.2-vision:11b" # ~8GB
+      # multimodal (vision + text) + coding
+      "gemma4:12b" # ~8GB
+      # multimodal edge (vision + audio + text)
+      "gemma4:e4b" # ~10GB
       # coding
-      "codegemma:7b" # ~5GB
-      "granite-code:8b" # ~5GB
+      "granite4:tiny" # ~4GB
       # reasoning / general purpose
       "phi4:14b" # ~9GB
       # general purpose
-      "mistral:7b" # ~4GB
-      "llama3.1:8b" # ~5GB
+      "mistral-nemo:12b" # ~7GB
       # lightweight general purpose
-      "phi4-mini:3.8b" # ~2.5GB
       "gemma3:4b" # ~3GB
     ];
     environmentVariables = {

--- a/modules/scale-signs/default.nix
+++ b/modules/scale-signs/default.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.mynixcfg.scale-signs;
 
-  externalPkgs = inputs.scale-signs.packages.${pkgs.system};
+  externalPkgs = inputs.scale-signs.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
   options.mynixcfg.scale-signs = {

--- a/modules/scale-simulator/default.nix
+++ b/modules/scale-simulator/default.nix
@@ -7,7 +7,7 @@
 let
   cfg = config.mynixcfg.scale-simulator;
 
-  externalPkgs = inputs.scale-signs.packages.${pkgs.system};
+  externalPkgs = inputs.scale-signs.packages.${pkgs.stdenv.hostPlatform.system};
 in
 {
   options.mynixcfg.scale-simulator = {

--- a/modules/tempo/default.nix
+++ b/modules/tempo/default.nix
@@ -47,6 +47,15 @@ in
           local.path = "${cfg.dataDir}/traces";
           wal.path = "${cfg.dataDir}/wal";
         };
+        # tempo 3.0 single-binary runs these modules by default and they
+        # write to /var/tempo, which is read-only under the service's
+        # systemd sandbox; inert on 2.10 where the modules don't run
+        backend_scheduler.local_work_path = "${cfg.dataDir}/backend-scheduler";
+        live_store = {
+          wal.path = "${cfg.dataDir}/live-store/traces";
+          shutdown_marker_dir = "${cfg.dataDir}/live-store/shutdown-marker";
+        };
+        block_builder.wal.path = "${cfg.dataDir}/block-builder/traces";
       };
     };
   };

--- a/tests/galleta.nix
+++ b/tests/galleta.nix
@@ -96,7 +96,8 @@
     galleta.wait_for_unit("kea-dhcp4-server.service")
     galleta.wait_for_unit("chronyd.service")
     galleta.wait_for_unit("sshd.service")
-    galleta.wait_for_unit("radvd.service")
+    # radvd disabled: router keeps IPv6 but does not advertise it to the LAN
+    galleta.fail("systemctl is-active radvd.service")
 
     # Validate BIND config
     galleta.succeed("named-checkconf ${nodes.galleta.services.bind.configFile}")


### PR DESCRIPTION
- disable ipv6 on the LAN by disabling radvd on the router, he tunnel seems to be rate limited by isp, keep tunnel
- bump inputs
- fix issue with tempo module on nixpkgs unstable
- temporarily allow EOL'd electron on desktops
- remove all warnings from `nix flake show`
- use bleeding edge openrct2 on watson
- speed up ollama-cuda compile times by scoping capabilities to exact card